### PR TITLE
Expose vendor cadical feature and format Cargo.toml files

### DIFF
--- a/cargo-symex/Cargo.toml
+++ b/cargo-symex/Cargo.toml
@@ -24,7 +24,7 @@ tracing-subscriber = "0.3"
 [features]
 logging = ["symex/log"]
 bitwuzla = ["symex/bitwuzla"]
-bitwuzla-vendor-cadical = ["symex/bitwuzla-vendor-cadical"]
+build-bitwuzla = ["symex/build-bitwuzla"]
 boolector = ["symex/boolector"]
 default = ["bitwuzla"]
 

--- a/symex/Cargo.toml
+++ b/symex/Cargo.toml
@@ -13,8 +13,8 @@ tracing = "0.1"
 transpiler = { path = "../symex/transpiler" }
 general_assembly = { path = "../symex/general_assembly" }
 
-bitwuzla = { git = "https://github.com/ivajon/boolector-rs.git", branch = "bitwuzla", optional = true }
 # SMT-backends.
+bitwuzla = { git = "https://github.com/ivajon/boolector-rs.git", branch = "bitwuzla", optional = true }
 boolector = { version = "0.4.3", optional = true }
 z3-sys = { version = "0.8.1", optional = true }
 
@@ -43,7 +43,7 @@ paste = "1.0.14"
 [features]
 # Solvers
 bitwuzla = ["dep:bitwuzla"]
-bitwuzla-vendor-cadical = ["dep:bitwuzla", "bitwuzla/vendor-cadical"]
+build-bitwuzla = ["dep:bitwuzla", "bitwuzla/vendor-cadical"]
 
 ## Deprecated since 0.2.0 as it does not support lambdas.
 boolector = ["dep:boolector", "deprecated"]


### PR DESCRIPTION
This adds a feature `bitwuzla-vendor-cadical` to `cargo-symex` which uses the backing `vendor-cadical` feature on `bitwuzla`.

Also added a `bitwuzla-vendor-cadical` feature to `symex`.

One could also have a `vendor-cadical` feature on both instead which does not include `bitwuzla`, but `vendor-cadical` then requires `bitwuzla` anyways, so i see no point. 