### PR TITLE
Add verbose results feature

### DIFF
--- a/cargo-symex/Cargo.toml
+++ b/cargo-symex/Cargo.toml
@@ -23,6 +23,7 @@ tracing-subscriber = "0.3"
 
 [features]
 logging = ["symex/log"]
+verbose-results = ["symex/verbose-results"]
 bitwuzla = ["symex/bitwuzla"]
 build-bitwuzla = ["symex/build-bitwuzla"]
 boolector = ["symex/boolector"]

--- a/symex/Cargo.toml
+++ b/symex/Cargo.toml
@@ -49,6 +49,8 @@ build-bitwuzla = ["dep:bitwuzla", "bitwuzla/vendor-cadical"]
 boolector = ["dep:boolector", "deprecated"]
 z3 = ["incomplete", "dep:z3-sys"]
 
+verbose-results = []
+
 # Denotes that a feature is experimental.
 experimental = []
 

--- a/symex/src/smt/bitwuzla/memory.rs
+++ b/symex/src/smt/bitwuzla/memory.rs
@@ -11,10 +11,7 @@ use crate::{
     memory::{MemoryError, BITS_IN_BYTE},
     project::Project,
     smt::{Context, ProgramMemory, SmtExpr, SmtFPExpr, SmtMap, SmtSolver},
-    trace,
-    warn,
-    Endianness,
-    UserStateContainer,
+    trace, warn, Endianness, UserStateContainer,
 };
 
 #[derive(Debug, Clone)]
@@ -438,34 +435,75 @@ impl<State: UserStateContainer> SmtMap for BitwuzlaMemory<State> {
 
 impl<State: UserStateContainer> Display for BitwuzlaMemory<State> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str("\tVariables:\r\n")?;
+        f.write_str("Variables:\r\n")?;
         for (key, value) in &self.variables {
-            write!(f, "\t\t{key} : {}\r\n", match value.get_constant() {
-                Some(_value) => value.to_binary_string(),
-                _ => strip(format!("{value:?}")),
-            })?;
+            // In reality, this should probably be a flag to cargo-symex or so...
+            #[cfg(feature = "verbose-results")]
+            write!(
+                f,
+                "\t\t{key} :\t {}\r\n",
+                match value.get_constant() {
+                    Some(_value) => {
+                        format!("Constant: 0b{}", value.to_binary_string())
+                    }
+                    _ => {
+                        format!("Solution: {}\n\t\t\t Expression: {}", value.to_binary_string(), strip(format!("{value:?}")))
+                    }
+                }
+            )?;
+            #[cfg(not(feature = "verbose-results"))]
+            write!(
+                f,
+                "\t\t{key} : {}\r\n",
+                match value.get_constant() {
+                    Some(_value) => value.to_binary_string(),
+                    _ => strip(format!("{value:?}")),
+                }
+            )?;
         }
         f.write_str("\tFP Variables:\r\n")?;
         for (key, value) in &self.fp_variables {
-            write!(f, "\t\t{key} : {}\r\n", match value.get_const() {
-                Some(value) => value.to_string(),
-                _ => strip(format!("{value:?}")),
-            })?;
+            write!(
+                f,
+                "\t\t{key} : {}\r\n",
+                match value.get_const() {
+                    Some(value) => value.to_string(),
+                    _ => strip(format!("{value:?}")),
+                }
+            )?;
         }
         f.write_str("\tRegister file:\r\n")?;
         for (key, value) in &self.register_file {
-            write!(f, "\t\t{key} : {}\r\n", match value.get_constant() {
-                Some(_value) => value.to_binary_string(),
-                _ => strip(format!("{value:?}")),
-            })?;
+            #[cfg(feature = "verbose-results")]
+            write!(
+                f,
+                "\t\t{key} :\t {}\r\n",
+                match value.get_constant() {
+                    Some(_value) => format!("Constant: 0b{}", value.to_binary_string()),
+                    _ => format!("Solution: {}\n\t\t\t Expression: {}", value.to_binary_string(), strip(format!("{value:?}"))),
+                }
+            )?;
+            #[cfg(not(feature = "verbose-results"))]
+            write!(
+                f,
+                "\t\t{key} : {}\r\n",
+                match value.get_constant() {
+                    Some(_value) => value.to_binary_string(),
+                    _ => strip(format!("{value:?}")),
+                }
+            )?;
         }
         f.write_str("\tFlags:\r\n")?;
 
         for (key, value) in &self.flags {
-            write!(f, "\t\t{key} : {}\r\n", match value.get_constant() {
-                Some(_value) => value.to_binary_string(),
-                _ => strip(format!("{value:?}")),
-            })?;
+            write!(
+                f,
+                "\t\t{key} : {}\r\n",
+                match value.get_constant() {
+                    Some(_value) => value.to_binary_string(),
+                    _ => strip(format!("{value:?}")),
+                }
+            )?;
         }
         Ok(())
     }

--- a/symex/src/smt/bitwuzla/memory.rs
+++ b/symex/src/smt/bitwuzla/memory.rs
@@ -440,7 +440,6 @@ impl<State: UserStateContainer> Display for BitwuzlaMemory<State> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("Variables:\r\n")?;
         for (key, value) in &self.variables {
-            // In reality, this should probably be a flag to cargo-symex or so...
             #[cfg(feature = "verbose-results")]
             write!(f, "\t\t{key} :\t {}\r\n", match value.get_constant() {
                 Some(_value) => {

--- a/symex/src/smt/bitwuzla/memory.rs
+++ b/symex/src/smt/bitwuzla/memory.rs
@@ -510,7 +510,12 @@ impl<State: UserStateContainer> Display for BitwuzlaMemory<State> {
 }
 
 fn strip(s: String) -> String {
+    #[cfg(not(feature = "verbose-results"))]
     if 50 < s.len() {
+        return "Large symbolic expression".to_string();
+    }
+    #[cfg(feature = "verbose-results")]
+    if 100 < s.len() {
         return "Large symbolic expression".to_string();
     }
     s

--- a/symex/src/smt/bitwuzla/memory.rs
+++ b/symex/src/smt/bitwuzla/memory.rs
@@ -11,7 +11,10 @@ use crate::{
     memory::{MemoryError, BITS_IN_BYTE},
     project::Project,
     smt::{Context, ProgramMemory, SmtExpr, SmtFPExpr, SmtMap, SmtSolver},
-    trace, warn, Endianness, UserStateContainer,
+    trace,
+    warn,
+    Endianness,
+    UserStateContainer,
 };
 
 #[derive(Debug, Clone)]
@@ -439,71 +442,47 @@ impl<State: UserStateContainer> Display for BitwuzlaMemory<State> {
         for (key, value) in &self.variables {
             // In reality, this should probably be a flag to cargo-symex or so...
             #[cfg(feature = "verbose-results")]
-            write!(
-                f,
-                "\t\t{key} :\t {}\r\n",
-                match value.get_constant() {
-                    Some(_value) => {
-                        format!("Constant: 0b{}", value.to_binary_string())
-                    }
-                    _ => {
-                        format!("Solution: {}\n\t\t\t Expression: {}", value.to_binary_string(), strip(format!("{value:?}")))
-                    }
+            write!(f, "\t\t{key} :\t {}\r\n", match value.get_constant() {
+                Some(_value) => {
+                    format!("Constant: 0b{}", value.to_binary_string())
                 }
-            )?;
+                _ => {
+                    format!("Solution: {}\n\t\t\t Expression: {}", value.to_binary_string(), strip(format!("{value:?}")))
+                }
+            })?;
             #[cfg(not(feature = "verbose-results"))]
-            write!(
-                f,
-                "\t\t{key} : {}\r\n",
-                match value.get_constant() {
-                    Some(_value) => value.to_binary_string(),
-                    _ => strip(format!("{value:?}")),
-                }
-            )?;
+            write!(f, "\t\t{key} : {}\r\n", match value.get_constant() {
+                Some(_value) => value.to_binary_string(),
+                _ => strip(format!("{value:?}")),
+            })?;
         }
         f.write_str("\tFP Variables:\r\n")?;
         for (key, value) in &self.fp_variables {
-            write!(
-                f,
-                "\t\t{key} : {}\r\n",
-                match value.get_const() {
-                    Some(value) => value.to_string(),
-                    _ => strip(format!("{value:?}")),
-                }
-            )?;
+            write!(f, "\t\t{key} : {}\r\n", match value.get_const() {
+                Some(value) => value.to_string(),
+                _ => strip(format!("{value:?}")),
+            })?;
         }
         f.write_str("\tRegister file:\r\n")?;
         for (key, value) in &self.register_file {
             #[cfg(feature = "verbose-results")]
-            write!(
-                f,
-                "\t\t{key} :\t {}\r\n",
-                match value.get_constant() {
-                    Some(_value) => format!("Constant: 0b{}", value.to_binary_string()),
-                    _ => format!("Solution: {}\n\t\t\t Expression: {}", value.to_binary_string(), strip(format!("{value:?}"))),
-                }
-            )?;
+            write!(f, "\t\t{key} :\t {}\r\n", match value.get_constant() {
+                Some(_value) => format!("Constant: 0b{}", value.to_binary_string()),
+                _ => format!("Solution: {}\n\t\t\t Expression: {}", value.to_binary_string(), strip(format!("{value:?}"))),
+            })?;
             #[cfg(not(feature = "verbose-results"))]
-            write!(
-                f,
-                "\t\t{key} : {}\r\n",
-                match value.get_constant() {
-                    Some(_value) => value.to_binary_string(),
-                    _ => strip(format!("{value:?}")),
-                }
-            )?;
+            write!(f, "\t\t{key} : {}\r\n", match value.get_constant() {
+                Some(_value) => value.to_binary_string(),
+                _ => strip(format!("{value:?}")),
+            })?;
         }
         f.write_str("\tFlags:\r\n")?;
 
         for (key, value) in &self.flags {
-            write!(
-                f,
-                "\t\t{key} : {}\r\n",
-                match value.get_constant() {
-                    Some(_value) => value.to_binary_string(),
-                    _ => strip(format!("{value:?}")),
-                }
-            )?;
+            write!(f, "\t\t{key} : {}\r\n", match value.get_constant() {
+                Some(_value) => value.to_binary_string(),
+                _ => strip(format!("{value:?}")),
+            })?;
         }
         Ok(())
     }


### PR DESCRIPTION
This feature gives a concrete example solution in the result printout for each variable ending up as an expression.

This is not expected to be generally useful, but will be nice as a didactic tool for our students.

Seems `rustfmt` went ham here also, we should probably just `rustfmt` the entire project to have an agreed upon code format for contributions.