### PR TITLE
Correct the in IT block check to correctly propagate the condition.

### DIFF
--- a/symex/src/arch/arm/v7.rs
+++ b/symex/src/arch/arm/v7.rs
@@ -377,7 +377,6 @@ impl<Override: ArchitectureOverride> Architecture<Override> for ArmV7EM {
         }
 
         if let Some(it) = it {
-            // NOTE: This check is based on InITBlock from the ARMv7-EM specification.
             if it.mask::<0, 3>() != 0 {
                 trace!("Pushing CONDITION {cond:?}");
                 state.architecture.as_v7().in_it_block = true;

--- a/symex/src/arch/arm/v7.rs
+++ b/symex/src/arch/arm/v7.rs
@@ -377,7 +377,8 @@ impl<Override: ArchitectureOverride> Architecture<Override> for ArmV7EM {
         }
 
         if let Some(it) = it {
-            if it.mask::<1, 3>() != 0b111 {
+            // NOTE: This check is based on InITBlock from the ARMv7-EM specification.
+            if it.mask::<0, 3>() != 0 {
                 trace!("Pushing CONDITION {cond:?}");
                 state.architecture.as_v7().in_it_block = true;
                 state.instruction_conditions.push_back(cond);


### PR DESCRIPTION
This PR aims to correct a bug in the ARMv7-EM translation unit. The previous implementation seems to have defined the InITBlock check based on whether the code was equal to 0b111, this is not what the standard says. This PR aims to rectify this to map correctly to what the standard says, e.g. inequality when compared to 0b0000.

